### PR TITLE
check that it's an object but not null (which is typeof 'object')

### DIFF
--- a/src/providers/scuttlebot.service.ts
+++ b/src/providers/scuttlebot.service.ts
@@ -394,7 +394,7 @@ export class ScuttlebotService {
 
             let imageId;
 
-            if (typeof data.value.content.image === 'object') {
+            if (data.value.content.image && typeof data.value.content.image === 'object') {
                 imageId = data.value.content.image.link;
             } else {
                 imageId = data.value.content.image;


### PR DESCRIPTION
This was giving me a type error because of some message which where image was null (which is typeof "object" in javascript) normally I just write a helper at the top and then use that in my code.

``` js
function isObject (o) { return o && 'object' === typeof o }
```